### PR TITLE
Fixed wrong escaping in code examples

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,3 @@
 name: squeryl
 markdown: kramdown
-pygments: true
+highlighter: rouge

--- a/docs/0.9.5/0.9.6.md
+++ b/docs/0.9.5/0.9.6.md
@@ -19,90 +19,69 @@ only it’s companion object
 #### In the next example, we defined an object SquerylEntrypointForMyApp that will be imported in an application wherever the DSL is used.
 
 <script type="syntaxhighlighter" class="brush: scala">
+<![CDATA[
 
-
-
-import org.squeryl.\_  
-import org.squeryl.dsl.\_  
-import org.joda.time.\_  
-import java.sql.Timestamp  
+import org.squeryl._
+import org.squeryl.dsl._
+import org.joda.time._
+import java.sql.Timestamp
 import java.sql.ResultSet
 
 object SquerylEntrypointForMyApp extends PrimitiveTypeMode {
 
-// optionally define keyed entities :  
-implicit object courseKED extends KeyedEntityDef\[Course,Int\] {  
-def getId(a:Course) = a.id  
-def isPersisted(a:Course) = a.id \> 0  
-def idPropertyName = “id”  
-override def optimisticCounterPropertyName = Some(“occVersionNumber”)  
-}
+  // optionally define keyed entities:
+  implicit object courseKED extends KeyedEntityDef[Course,Int] {
+    def getId(a:Course) = a.id
+    def isPersisted(a:Course) = a.id > 0
+    def idPropertyName = “id”
+    override def optimisticCounterPropertyName = Some(“occVersionNumber”)
+  }
 
-// optionally define custom types :
+  // optionally define custom types:
+  implicit val jodaTimeTEF = new NonPrimitiveJdbcMapper[Timestamp, DateTime, TTimestamp](timestampTEF, this) {
 
-implicit val jodaTimeTEF = new NonPrimitiveJdbcMapper\[Timestamp,
-DateTime, TTimestamp\](timestampTEF, this) {
+  /* Here we implement functions fo convert to and from the native JDBC type*/
 
-/  
-\* Here we implement functions fo convert to and from the native JDBC
-type  
-\*/
+    def convertFromJdbc(t: Timestamp) = new DateTime(t)
+    def convertToJdbc(t: DateTime) = new Timestamp(t.getMillis())
+  }
 
-def convertFromJdbc(t: Timestamp) = new DateTime(t)  
-def convertToJdbc(t: DateTime) = new Timestamp(t.getMillis())  
-}
+  /* We define this one here to allow working with Option of our new type, this also allows the ‘nvl’ function to work */
+  implicit val optionJodaTimeTEF =
+    new TypedExpressionFactory[Option[DateTime], TOptionTimestamp]
+    with DeOptionizer[Timestamp, DateTime, TTimestamp, Option[DateTime], TOptionTimestamp] {
+      val deOptionizer = jodaTimeTEF
+  }
 
-/  
-\* We define this one here to allow working with Option of our new type,
-this allso  
-\* allows the ‘nvl’ function to work  
-\*/  
-implicit val optionJodaTimeTEF =  
-new TypedExpressionFactory\[Option\[DateTime\], TOptionTimestamp\]  
-with DeOptionizer\[Timestamp, DateTime, TTimestamp, Option\[DateTime\],
-TOptionTimestamp\] {
+  /* the following are necessary for the AST lifting */
+  implicit def jodaTimeToTE(s: DateTime) = jodaTimeTEF.create(s)
 
-val deOptionizer = jodaTimeTEF  
-}
+  implicit def optionJodaTimeToTE(s: Option[DateTime]) =
+    optionJodaTimeTEF.create(s)
+  }
 
-/  
-\* the following are necessary for the AST lifting  
-\*/  
-implicit def jodaTimeToTE(s: DateTime) = jodaTimeTEF.create(s)
+// elsewhere in the application:
 
-implicit def optionJodaTimeToTE(s: Option\[DateTime\]) =
-optionJodaTimeTEF.create(s)  
-}
-
-// elsewhere in the application :
-
-import SquerylEntrypointForMyApp.\_
-
-
+import SquerylEntrypointForMyApp._
+]]>
 
 </script>
 
-**Warning**: Although deprecared, the org.squeryl.PrimitiveTypeMode
-companion object can still be used for backward compatibility.  
-If it is used, it **cannot** be used in a same application with other
-instance of the  
-org.squeryl.PrimitiveTypeMode trait.
+**Warning**: Although deprecated, the org.squeryl.PrimitiveTypeMode companion object can still be used for backward compatibility.
+If it is used, it **cannot** be used in a same application with other instance of the org.squeryl.PrimitiveTypeMode trait.
 
 <script type="syntaxhighlighter" class="brush: scala">
 
-
-
-// WRONG, do not do this :
+<![CDATA[
+// WRONG, do not do this:
 
 object SquerylEntrypointForMyApp extends org.squeryl.PrimitiveTypeMode
 
-import SquerylEntrypointForMyApp.\_
+import SquerylEntrypointForMyApp._
 
 // elsewhere in the application
 
-import org.squeryl.PrimitiveTypeMode.\_  
-}
-
-
+import org.squeryl.PrimitiveTypeMode._
+]]>
 
 </script>

--- a/docs/0.9.5/arbitrary-select-expressions.md
+++ b/docs/0.9.5/arbitrary-select-expressions.md
@@ -12,22 +12,13 @@ Sometimes the expressions needs to be evaluated on the database side,
 this is what the **&** function does :
 
 <script type="syntaxhighlighter" class="brush: scala">
+<![CDATA[
+// the * is done on the client side:
+from(artists)(a => select(a.id * 1000))
 
-
-
-// the \* is done on the client side :
-
-from(artists)(a =\>  
-select(a.id \* 1000)  
-)
-
-// in this case it is computed by the database :
-
-from(artists)(a =\>  
-select(&(a.id \* 1000))  
-)  
-
-
+// in this case it is computed by the database:
+from(artists)(a => select(&(a.id * 1000)))
+]]>
 </script>
 
 -   Note that the return type are equivalent in both cases, i.e. both
@@ -36,13 +27,10 @@ select(&(a.id \* 1000))
 A select can have more than one invocation of & :
 
 <script type="syntaxhighlighter" class="brush: scala">
+<![CDATA[
 
+val q: Query[Tuple2[Double, String]] = from(artists)(a => 
+  select((&(a.id * 1000), &(a.firstName || a.lastName))))
 
-
-val q: Query\[Tuple2\[Double, String\]\] =  
-from(artists)(a =\>  
-select((&(a.id \* 1000), &(a.firstName \|\| a.lastName)))  
-)  
-
-
+]]>
 </script>

--- a/docs/0.9.5/complete-example.md
+++ b/docs/0.9.5/complete-example.md
@@ -5,174 +5,144 @@ headtitle: Examples -
 ---
 
 <script type="syntaxhighlighter" class="brush: scala">
-
-
-
+<![CDATA[
 package org.squeryl.demos;
 
-import org.squeryl.PrimitiveTypeMode.\_  
-import org.squeryl.adapters.H2Adapter  
+import org.squeryl.PrimitiveTypeMode._
+import org.squeryl.adapters.H2Adapter
 import org.squeryl.{Session, KeyedEntity, Schema}
 
-// The root object of the schema. Inheriting KeyedEntity\[T\] is not
-mandatory  
-// it just makes primary key methods available (delete and lookup) on
-tables.  
-class MusicDbObject extends KeyedEntity\[Long\] {  
-var id: Long = 0  
+// The root object of the schema. Inheriting KeyedEntity[T] is not mandatory
+// it just makes primary key methods available (delete and lookup) on tables.
+class MusicDbObject extends KeyedEntity[Long] {
+  var id: Long = 0
 }
 
 class Artist(var name:String) extends MusicDbObject {
 
-// this returns a Query\[Song\] which is also an Iterable\[Song\] :  
-def songs = from(MusicDb.songs)(s =\> where(s.artistId === id)
-select(s))
+  // this returns a Query[Song] which is also an Iterable[Song]:
+  def songs = from(MusicDb.songs)(s => where(s.artistId === id) select(s))
 
-def newSong(title: String, filePath: Option\[String\]) =  
-MusicDb.songs.insert(new Song(title, id, filePath))  
+  def newSong(title: String, filePath: Option[String]) =
+    MusicDb.songs.insert(new Song(title, id, filePath))
 }
 
-// Option\[\] members are mapped to nullable database columns,  
-// otherwise they have a NOT NULL constraint.  
-class Song(var title: String, var artistId: Long, var filePath:
-Option\[String\]) extends MusicDbObject {
+// Option[] members are mapped to nullable database columns,
+// otherwise they have a NOT NULL constraint.
+class Song(var title: String, var artistId: Long, var filePath: Option[String]) extends MusicDbObject {
 
-// IMPORTANT : currently classes with Option\[\] members **must**
-provide a zero arg  
-// constructor where every Option\[T\] member gets initialized with
-Some(t:T).  
-// or else Squeryl will not be able to reflect the type of the field,
-and an exception will  
-// be thrown at table instantiation time.  
-def this() = this(“”, 0, Some(“”))
+  // IMPORTANT: currently classes with Option[] members **must** provide a zero arg
+  // constructor where every Option[T] member gets initialized with Some(t:T).
+  // or else Squeryl will not be able to reflect the type of the field, and an exception will
+  // be thrown at table instantiation time.
+  def this() = this(“”, 0, Some(“”))
 
-// the schema can be imported in the scope, to lighten the syntax :  
-import MusicDb.\_
+  // the schema can be imported in the scope, to lighten the syntax:
+  import MusicDb._
 
-// An alternative (shorter) syntax for single table queries :  
-def artist = artists.where(a =\> a.id === artistId).single
+  // An alternative (shorter) syntax for single table queries:
+  def artist = artists.where(a => a.id === artistId).single
 
-// Another alternative for lookup by primary key, since Artist is a  
-// KeyedEntity\[Long\], it’s table has a lookup\[Long\](k: Long)  
-// method available :  
-def lookupArtist = artists.lookup(artistId)  
+  // Another alternative for lookup by primary key, since Artist is a
+  // KeyedEntity[Long], it’s table has a lookup[Long](k: Long)
+  // method available:
+  def lookupArtist = artists.lookup(artistId)
 }
 
-class Playlist(var name: String, var path: String) extends MusicDbObject
-{
+class Playlist(var name: String, var path: String) extends MusicDbObject {
 
-import MusicDb.\_
+  import MusicDb._
 
-// a two table join :  
-def songsInPlaylistOrder =  
-from(playlistElements, songs)((ple, s) =\>  
-where(ple.playlistId = id and ple.songId = s.id)  
-select(s)  
-orderBy(ple.songNumber asc)  
-)
+  // a two table join:
+  def songsInPlaylistOrder = from(playlistElements, songs)((ple, s) =>
+    where(ple.playlistId = id and ple.songId = s.id) 
+    select(s) 
+    orderBy(ple.songNumber asc))
 
-def addSong(s: Song) = {
+  def addSong(s: Song) = {
 
-// Note how this query can be implicitly converted to an Int since it
-returns  
-// at most one row, this applies to all single column aggregate queries
-with no groupBy clause.  
-// The nvl function in this example changed the return type to Int,
-from  
-// Option\[Int\], since the ‘max’ function (like all aggregates, ‘count’
-being the only exception).  
-val nextSongNumber: Int =  
-from(playlistElements)(ple =\>  
-where(ple.playlistId === id)  
-compute(nvl(max(ple.songNumber), 0))  
-)
+    // Note how this query can be implicitly converted to an Int since it returns
+    // at most one row, this applies to all single column aggregate queries with no groupBy clause.
+    // The nvl function in this example changed the return type to Int, from
+    // Option[Int], since the ‘max’ function (like all aggregates, ‘count’ being the only exception).
+    val nextSongNumber: Int =
+      from(playlistElements)(ple =>
+        where(ple.playlistId === id)
+        compute(nvl(max(ple.songNumber), 0)))
 
-playlistElements.insert(new PlaylistElement(nextSongNumber, id, s.id))  
+    playlistElements.insert(new PlaylistElement(nextSongNumber, id, s.id))
+  }
+
+  // New concept: a group query with aggregate functions return GroupWithMeasures[K,M]
+  // where K and M are tuples whose members correspond to the group by list and compute list
+  // respectively.
+  private def _songCountByArtistId =
+    from(artists, songs)((a,s) =>
+      where(a.id === s.artistId)
+      groupBy(a.id)
+      compute(count))
+
+  // Queries are nestable just as they would in SQL
+  def songCountForAllArtists =
+    from(_songCountByArtistId, artists)((sca,a) =>
+      where(sca.key === a.id)
+      select((a, sca.measures)))
+
+  // Unlike SQL, a function that returns a query can be nested
+  // as if it were a query, notice the nesting of ‘songsOf’
+  // allowing DRY persistence layers as reuse is enhanced.
+  def latestSongFrom(artistId: Long) =
+    from(songsOf(artistId))(s =>
+      select(s)
+      orderBy(s.id desc)
+    ).headOption
+
+  def songsOf(artistId: Long) =
+    from(playlistElements, songs)((ple,s) =>
+      where(id = ple.playlistId and ple.songId = s.id and s.artistId === artistId)
+      select(s))
 }
 
-// New concept : a group query with aggregate functions return
-GroupWithMeasures\[K,M\]  
-// where K and M are tuples whose members correspond to the group by
-list and compute list  
-// respectively.  
-private def \_songCountByArtistId =  
-from(artists, songs)((a,s) =\>  
-where(a.id === s.artistId)  
-groupBy(a.id)  
-compute(count)  
-)
-
-// Queries are nestable just as they would in SQL  
-def songCountForAllArtists =  
-from(\_songCountByArtistId, artists)((sca,a) =\>  
-where(sca.key === a.id)  
-select((a, sca.measures))  
-)
-
-// Unlike SQL, a function that returns a query can be nested  
-// as if it were a query, notice the nesting of ‘songsOf’  
-// allowing DRY persistence layers as reuse is enhanced.  
-def latestSongFrom(artistId: Long) =  
-from(songsOf(artistId))(s =\>  
-select(s)  
-orderBy(s.id desc)  
-).headOption
-
-def songsOf(artistId: Long) =  
-from(playlistElements, songs)((ple,s) =\>  
-where(id = ple.playlistId and ple.songId = s.id and s.artistId ===
-artistId)  
-select(s)  
-)  
-}
-
-class PlaylistElement(var songNumber: Int, var playlistId: Long, var
-songId: Long)
+class PlaylistElement(var songNumber: Int, var playlistId: Long, var songId: Long)
 
 object MusicDb extends Schema {
-
-val songs = table\[Song\]  
-val artists = table\[Artist\]  
-val playlists = table\[Playlist\]  
-val playlistElements = table\[PlaylistElement\]  
+  val songs = table[Song]
+  val artists = table[Artist]
+  val playlists = table[Playlist]
+  val playlistElements = table[PlaylistElement]
 }
 
 object KickTheTires {
 
-import MusicDb.\_
+  import MusicDb._
 
-//A Squeryl session is a thin wrapper over a JDBC connection :  
-Class.forName(“org.h2.Driver”);  
-val session = Session.create(  
-java.sql.DriverManager.getConnection(“jdbc:h2:\~/test”, “sa”, “”),  
-//Currently there are adapters for Oracle, Postgres, MySQL and H2 :  
-new H2Adapter  
-)
+  //A Squeryl session is a thin wrapper over a JDBC connection:
+  Class.forName(“org.h2.Driver”);
+  val session = Session.create(
+    java.sql.DriverManager.getConnection(“jdbc:h2:\~/test”, “sa”, “”),
+    //Currently there are adapters for Oracle, Postgres, MySQL and H2:
+    new H2Adapter
+  )
 
-try {  
-session.work {  
-// database access code goes here  
-test  
-session.connection.commit  
-}  
-}  
-catch {  
-case e:Exception =\> session.connection.rollback  
+  try {
+    session.work {
+      // database access code goes here
+      test
+      session.connection.commit
+    }
+  } catch {
+    case e:Exception => session.connection.rollback
+  }
+
+  def test = {
+    val herbyHancock = artists.insert(new Artist(“Herby Hancock”))
+    val ponchoSanchez = artists.insert(new Artist(“Poncho Sanchez”))
+    val mongoSantaMaria = artists.insert(new Artist(“Mongo Santa Maria”))
+
+    val watermelonMan = herbyHancock.newSong(“Watermelon Man”, None)
+    val besameMama = mongoSantaMaria.newSong(“Besame Mama”, Some(“c:/MyMusic/besameMama.flac”))
+    val freedomSound = ponchoSanchez.newSong(“Freedom Sound”, None)
+  }
 }
-
-def test = {
-
-val herbyHancock = artists.insert(new Artist(“Herby Hancock”))  
-val ponchoSanchez = artists.insert(new Artist(“Poncho Sanchez”))  
-val mongoSantaMaria = artists.insert(new Artist(“Mongo Santa Maria”))
-
-val watermelonMan = herbyHancock.newSong(“Watermelon Man”, None)  
-val besameMama = mongoSantaMaria.newSong(“Besame Mama”,
-Some(“c:/MyMusic/besameMama.flac”))  
-val freedomSound = ponchoSanchez.newSong(“Freedom Sound”, None)  
-}  
-}
-
-
-
+]]>
 </script>

--- a/docs/0.9.5/composite-keys.md
+++ b/docs/0.9.5/composite-keys.md
@@ -15,16 +15,11 @@ Consider the following example where CourseAssignment is a
 KeyedEntity\[CompositeKey2\[Long,Long\]\]
 
 <script type="syntaxhighlighter" class="brush: scala">
-
-
-
-class CourseAssignment(val courseId: Long, val professorId: Long)
-extends KeyedEntity\[CompositeKey2\[Long,Long\]\] {
-
-def id = compositeKey(courseId, professorId)  
-}  
-
-
+<![CDATA[
+class CourseAssignment(val courseId: Long, val professorId: Long) extends KeyedEntity[CompositeKey2[Long,Long]] {
+  def id = compositeKey(courseId, professorId)
+}
+]]>
 </script>
 
 CourseAssignment.id is a unique identifier for a CourseAssignment. In
@@ -58,50 +53,36 @@ relations (see : [issue
 25](http://www.assembla.com/spaces/squeryl/tickets/25))
 
 <script type="syntaxhighlighter" class="brush: scala">
-
-
-
+<![CDATA[
 val aCourseAssignment = courseAssignments.where(…).single
 
-val q1 =  
-courseAssignments.where(\_.id === aCourseAssignment.id)
+val q1 = courseAssignments.where(_.id === aCourseAssignment.id)
 
-val q2 =  
-courseAssignments.where(\_.id ===(113243L, 26543546L))
+val q2 = courseAssignments.where(_.id ===(113243L, 26543546L))
 
 println(q.statement)
-
-
-
+]]>
 </script>
+
 <script type="syntaxhighlighter" class="brush: sql">
-
-
-
-Select  
-CourseAssignment1.professorId as CourseAssignment1\_professorId,  
-CourseAssignment1.courseId as CourseAssignment1\_courseId  
-From  
-CourseAssignment CourseAssignment1  
-Where  
+<![CDATA[
+Select
+CourseAssignment1.professorId as CourseAssignment1_professorId,
+CourseAssignment1.courseId as CourseAssignment1_courseId
+From
+CourseAssignment CourseAssignment1
+Where
 ((CourseAssignment1.courseId = 113243) and
 (CourseAssignment1.professorId = 26543546))
-
-
-
+]]>
 </script>
 <script type="syntaxhighlighter" class="brush: scala">
-
-
-
+<![CDATA[
 val aCourseAssignment = courseAssignments.where(…).single
 
-val q1 =  
-courseAssignments.where(  
-\_.id.courseId = aCourseAssignment.courseId and
-      \_.id.professorId = aCourseAssignment.professorId  
-)
-
-
-
+val q1 =
+  courseAssignments.where(
+    _.id.courseId = aCourseAssignment.courseId and
+      _.id.professorId = aCourseAssignment.professorId)
+]]>
 </script>

--- a/docs/0.9.5/contributing.md
+++ b/docs/0.9.5/contributing.md
@@ -25,19 +25,15 @@ When that is not possible, sending the AST of the query
 (with Query\[T\].dumpAst) is also helpful :
 
 <script type="syntaxhighlighter" class="brush: scala">
-
-
-val q =  
-from(artists, songs)((a,s) =\>  
-where(a.id === s.artistId)  
-groupBy(a.id)  
-compute(count)  
-)
+<![CDATA[
+val q =
+  from(artists, songs)((a,s) =>
+    where(a.id === s.artistId)
+    groupBy(a.id)
+    compute(count))
 
 println(q.dumpAst)
-
-
-
+]]>
 </script>
 
 Submitting Ideas and Issues

--- a/docs/0.9.5/custom-functions.md
+++ b/docs/0.9.5/custom-functions.md
@@ -10,54 +10,42 @@ returns a String
 You can define :
 
 <script type="syntaxhighlighter" class="brush: scala">
+<![CDATA[
 
+class SHA1(e: StringExpression[String], m:OutMapper[String]) 
+  extends FunctionNode[String](“sha1”, Some(m), Seq(e)) 
+  with StringExpression[String]
 
-
-class SHA1(e: StringExpression\[String\], m:OutMapper\[String\])  
-extends FunctionNode\[String\](“sha1”, Some(m), Seq(e)) with
-StringExpression\[String\]
-
-def sha1(e: StringExpression\[String\])(implicit m:OutMapper\[String\])
-= new SHA1(e,m)
-
-
-
+def sha1(e: StringExpression[String])(implicit m:OutMapper[String]) = new SHA1(e,m)
+]]>
 </script>
 
 Then you can use the sha1 function in expressions :
 
 <script type="syntaxhighlighter" class="brush: scala">
+<![CDATA[
 
+def sha1Of(id: Long) =
+  from(aTable)(u=> where(u.id === id) select(&(sha1(u.aStringField)))
 
-
-def sha1Of(id: Long) =  
-from(aTable)(u=\> where(u.id === id) select(&(sha1(u.aStringField)))
-
-def isSha1Equal(id: Long, s: String) =  
-from(aTable)(u=\> where(u.id = id and sha1(u.aStringField) = s)).Count
-== 1
-
-
-
+def isSha1Equal(id: Long, s: String) =
+  from(aTable)(u=> where(u.id = id and sha1(u.aStringField) = s)).Count == 1
+]]>
 </script>
 
 The arguments and return type of your custom function need be one of the
 following Squeryl types (defined in org.squeryl.dsl) :
 
 <script type="syntaxhighlighter" class="brush: scala">
-
-
-
-trait NumericalExpression\[A\]  
-trait StringExpression\[B\]  
-trait DateExpression\[C\]  
-trait BooleanExpression\[D\]
-
-
-
+<![CDATA[
+trait NumericalExpression[A]
+trait StringExpression[B]
+trait DateExpression[C]
+trait BooleanExpression[D]
+]]>
 </script>
 
-Where :
+Where: 
 
 -   A is Int, Long, Float, Double, BigDecimal or Option\[Int\],
     Option\[Long\], etc…
@@ -71,35 +59,32 @@ PrimitiveTypeMode, CustomTypeMode and RecordTypeMode
 (org.squeryl.dsl.TypeArithmetic))
 
 <script type="syntaxhighlighter" class="brush: scala">
+<![CDATA[
 
-
-
-// For Squeryl versions before 0.9.5-Beta, OutMappers need to be  
+// For Squeryl versions before 0.9.5-Beta, OutMappers need to be
 // created and given as argument to FunctionNode
 
-def m1:OutMapper\[String\] = new OutMapper\[String\] {  
-def doMap(rs: ResultSet) = rs.getString(index)  
-def sample = “”  
+def m1:OutMapper[String] = new OutMapper[String] {
+  def doMap(rs: ResultSet) = rs.getString(index)
+  def sample = “”
 }
 
-class SHA1(e: StringExpression\[String\])  
-extends FunctionNode\[String\](“sha1”, Some(m1), Seq(e)) with
-StringExpression\[String\]
+class SHA1(e: StringExpression[String])
+  extends FunctionNode[String](“sha1”, Some(m1), Seq(e)) with
+  StringExpression[String]
 
-def sha1(e: StringExpression\[String\]) = new SHA1(e,m)
+def sha1(e: StringExpression[String]) = new SHA1(e,m)
 
-def m2:OutMapper\[Option\[StringType\]\] = new
-OutMapper\[Option\[String\]\] {  
-def doMap(rs: ResultSet) = {  
-val v = rs.getString(index)  
-if(rs.wasNull)  
-None  
-else  
-Some(v)  
-}  
-def sample = Some(“”)  
+def m2:OutMapper[Option[StringType]] = new OutMapper[Option[String]] {
+  def doMap(rs: ResultSet) = {
+    val v = rs.getString(index)
+    if(rs.wasNull)
+      None
+    else
+      Some(v)
+  }
+  def sample = Some(“”)
 }
-
-
+]]>
 
 </script>

--- a/docs/0.9.5/dynamic-queries.md
+++ b/docs/0.9.5/dynamic-queries.md
@@ -25,56 +25,51 @@ query
 Example :
 
 <script type="syntaxhighlighter" class="brush: scala">
+<![CDATA[
 
+def searchForBooks(authorLastName: Option[String], bookTitle: String) =
+  from(authors.inhibitWhen(authorName  None), books)((a,b) =>
+    where(a.get.lastName like authorLastName.get and b.title like bookTitle and a.get.id = b.authorId)
+    select((b,a)))
 
+val result1:List[(Book,Option(Author))] = searchForBooks(None, “Un Loup est un loup”).toList
 
-def searchForBooks(authorLastName: Option\[String\], bookTitle: String)
-=  
-from(authors.inhibitWhen(authorName  None), books)((a,b)=\>
-        where(a.get.lastName like authorLastName.get and b.title like bookTitle and a.get.id =
-b.authorId)  
-select((b,a))  
-)
-
-val result1:List\[(Book,Option(Author))\] = searchForBooks(None, “Un
-Loup est un loup”).toList
-
-val result2:List\[(Book,Option(Author))\] = searchForBooks(“Tolstoi”,
-“War and Peace”).toList  
-
+val result2:List[(Book,Option(Author))] = searchForBooks(“Tolstoi”,“War and Peace”).toList
+]]>
 
 </script>
 
-Notice the Option\[\] in the result type of the query, and how the
-Author  
-table disappears from the generated SQL base on the input of
-**inhibitWhen** :
+Notice the Option\[\] in the result type of the query, and how the Author
+table disappears from the generated SQL base on the input of **inhibitWhen**:
+
+— first query: searchForBooks(None, “Un Loup est un loup”).toList
 
 <script type="syntaxhighlighter" class="brush: sql">
+<![CDATA[
 
-
-
-— first query : searchForBooks(None, “Un Loup est un loup”).toList
-
-Select \*  
-from  
-Book b  
-where  
-b.title like ? — ‘Un Loup est un loup’
+Select *
+  from
+  Book b
+  where
+  b.title like ? — ‘Un Loup est un loup’
+]]>
 
 — second query : searchForBooks(“Tolstoi”, “War and Peace”).toList
 
-Select \*  
-from  
-Author a,  
-Book b  
-where  
-a.lastName like ? and — “Tolstoi”  
-b.title like ? and — “War and Peace”  
-a.id = b.authorId  
+<script type="syntaxhighlighter" class="brush: sql">
+<![CDATA[
 
+Select *
+  from
+  Author a,
+  Book b
+  where
+    a.lastName like ? and — “Tolstoi”
+    b.title like ? and — “War and Peace”
+    a.id = b.authorId
+]]>
 
 </script>
 
-<a name='dyn-where-clause'></a>  
+<a name='dyn-where-clause'></a>
 {% include 0.9.5/feature-dyn-where-clause.html%}

--- a/docs/0.9.5/faq-caching.md
+++ b/docs/0.9.5/faq-caching.md
@@ -13,11 +13,13 @@ caching with lazy loading is possible :
 
 <script type="syntaxhighlighter" class="brush: scala">
 
+<![CDATA[
 
-class Song(val id, val title: String, val artistId: Long) {  
-lazy val artist = artists.where(a =\> a.id === artistId).single  
-}  
+class Song(val id, val title: String, val artistId: Long) {
+  lazy val artist = artists.where(a => a.id === artistId).single
+}
 
+]]>
 
 </script>
 

--- a/docs/0.9.5/faq-relations.md
+++ b/docs/0.9.5/faq-relations.md
@@ -15,18 +15,15 @@ with more reuse. Consider for example a “one to many” relation :
 
 <script type="syntaxhighlighter" class="brush: scala">
 
-
-
+<![CDATA[
 class Song(val id, val title: String, val artistId: Long, val year) {
-
-def artist = artistsTable.where(a =\> a.id === artistId).single  
+  def artist = artistsTable.where(a => a.id === artistId).single
 }
 
 class Artist(val id: Long, val name:String) {
-
-def songs = from(songsTable).where(s =\> s.artistId === id)  
-}  
-
+  def songs = from(songsTable).where(s => s.artistId === id)
+}
+]]>
 
 </script>
 
@@ -52,10 +49,11 @@ Here’s how it happens, suppose you execute the following :
 <script type="syntaxhighlighter" class="brush: scala">
 
 
+<![CDATA[
 
-for(so \<- jamesBrown.songs.where(s =\> s.year \<= 1965))  
-println(so.title)  
-
+for(so <- jamesBrown.songs.where(s => s.year <= 1965))
+  println(so.title)
+]]>
 
 </script>
 

--- a/docs/0.9.5/faq-why-not-jpa.md
+++ b/docs/0.9.5/faq-why-not-jpa.md
@@ -12,73 +12,68 @@ Can you spot the typo in this JPA query ?
 
 <script type="syntaxhighlighter" class="brush: java">
 
+<![CDATA[
 
-//JPA :  
-Query query =  
-em.createQuery(  
-“select a,b,p from authors, books, publisher ” +  
-“where b.subjectId = :idOfSubject and ” +  
-" a.id = b.authorId and " +  
-" b.publiserId = p.id "  
+//JPA:
+Query query = em.createQuery(
+  “select a,b,p from authors, books, publisher ” +
+  “where b.subjectId = :idOfSubject and ” +
+  " a.id = b.authorId and " +
+  " b.publiserId = p.id "  
 );
 
-query.setParameter(“idOfSubject”, idOfSubject);  
-
+query.setParameter(“idOfSubject”, idOfSubject);
+]]>
 
 </script>
 
 **Let’s hope that you can, because the compiler won’t tell you !**
 
-If you happen to rename a column, change it’s type, remove it, etc.  
+If you happen to rename a column, change it’s type, remove it, etc. 
 the compiler will be of no help.
 
-If you use JPAs relation mechanism to *navigate* through the object
-graph,  
-like the following example illustrates, you will regain type safety,  
-but at the cost of horrible performance,  
-Can you count the number of database calls resulting from this JPA query
-?
+If you use JPAs relation mechanism to *navigate* through the object graph,
+like the following example illustrates, you will regain type safety,
+but at the cost of horrible performance,
+Can you count the number of database calls resulting from this JPA query?
 
 <script type="syntaxhighlighter" class="brush: java">
 
+<![CDATA[
 
-
-Iterable<Book> books = bookEntityManager.findBySubjectId(idOfSubject);  
-while(books.hasNext()) {  
-Book b = books.next();  
-Author a = b.getAuthor();  
-Publisher p = b.getPublisher();  
-System.out.println(b.getTitle() + " by " + a.getFullName() + " published
-by " + p.getName());  
-}  
-
+Iterable<Book> books = bookEntityManager.findBySubjectId(idOfSubject);
+while(books.hasNext()) {
+  Book b = books.next();
+  Author a = b.getAuthor();
+  Publisher p = b.getPublisher();
+  System.out.println(b.getTitle() + " by " + a.getFullName() + " published by " + p.getName());
+}
+]]>
 
 </script>
 
-The answer is : two database round trips for every row returned by the
-findBySubjectId query,  
-an N-ary relation typically causes O (N-1) calls to the database, which
-can have disastrous  
+The answer is : two database round trips for every row returned by the findBySubjectId query,
+an N-ary relation typically causes O (N-1) calls to the database, which can have disastrous
 performance consequences.
 
-Squeryl allows you to combine the efficiency of the first approach  
+Squeryl allows you to combine the efficiency of the first approach
 (the query is done in a single database call), and the type safety of
-the second :
+the second:
 
 <script type="syntaxhighlighter" class="brush: scala">
 
+<![CDATA[
 
-val q =  
-from(authors, books, publisher)((a,b,p) =\>  
-where(b.subjectId = idOfSubject and
-          a.id = b.authorId and  
-b.publisherId === p.id)  
-select((a,b,p))  
-)  
-for(r \<- q)  
-println(r.\_2.title + " by " + r.\_1.fullName + " published by " +
-p.\_3.name)  
+val q =
+  from(authors, books, publisher)((a,b,p) =>
+    where(b.subjectId = idOfSubject and
+          a.id = b.authorId and
+          b.publisherId === p.id)
+   select((a,b,p)))
 
+for(r <- q)
+  println(r._2.title + " by " + r._1.fullName + " published by " + p._3.name)
+]]>
 
 </script>
 

--- a/docs/0.9.5/getting-started.md
+++ b/docs/0.9.5/getting-started.md
@@ -17,25 +17,27 @@ Declare the Squeryl dependency in the SBT project definiition
 
 <script type="syntaxhighlighter" class="brush: scala">
 
-libraryDependencies <span class="underline"></span>= Seq(  
-“org.squeryl” “squeryl” % “0.9.5-7”,  
-yourDatabaseDependency  
+<![CDATA[
+
+libraryDependencies ++= Seq(
+  “org.squeryl” “squeryl” % “0.9.5-7”,
+  yourDatabaseDependency
 )
 
-//yourDatabaseDependency is one of the supported databases :
+//yourDatabaseDependency is one of the supported databases:
 
-val h2 = “com.h2database” % “h2” % “1.2.127”  
-val mysqlDriver = “mysql” % “mysql-connector-java” % “5.1.10”  
-val posgresDriver = “postgresql” % “postgresql” % “8.4-701.jdbc4”  
-val msSqlDriver = “net.sourceforge.jtds” % “jtds” % “1.2.4”  
+val h2 = “com.h2database” % “h2” % “1.2.127”
+val mysqlDriver = “mysql” % “mysql-connector-java” % “5.1.10”
+val posgresDriver = “postgresql” % “postgresql” % “8.4-701.jdbc4”
+val msSqlDriver = “net.sourceforge.jtds” % “jtds” % “1.2.4”
 val derbyDriver = “org.apache.derby” % “derby” % “10.7.1.1”
+]]>
 
 </script>
 
-***Note*** : *The Oracle driver is not available via SBT/Maven, you will
-have to downloaded manually.*
+***Note*** : *The Oracle driver is not available via SBT/Maven, you will have to downloaded manually.*
 
-The remaining steps are :
+The remaining steps are:
 
 1.  [Bootstrap the session
     factory](http://squeryl.org/sessions-and-tx.html)
@@ -48,10 +50,9 @@ run queries.
 ### Manual dependency management
 
 If you want to manage your dependencies without SBT or Maven, you will
-need the following jars :
+need the following jars:
 
--   The Scala runtime jar, version 2.11.x, 2.10.x, 2.9.3, 2.9.2, 2.9.1,
-    2.9.0
+-   The Scala runtime jar, version 2.11.x, 2.10.x, 2.9.3, 2.9.2, 2.9.1, 2.9.0
 -   The Squeryl jar found
     [here](http://github.com/max-l/Squeryl/downloads)
 -   The CGLIB cglib-nodep-2.2.jar, found

--- a/docs/0.9.5/group-and-aggregate.md
+++ b/docs/0.9.5/group-and-aggregate.md
@@ -49,14 +49,14 @@ Here is an example, the following Squeryl statement :
 
 <script type="syntaxhighlighter" class="brush: scala">
 
+<![CDATA[
 
-def songCountByArtistId: Query\[GroupWithMeasures\[Long,Long\]\] =  
-from(artists, songs)((a,s) =\>  
-where(a.id === s.artistId)  
-groupBy(a.id)  
-compute(countDistinct(s.id))  
-)  
-
+def songCountByArtistId: Query[GroupWithMeasures[Long,Long]] =
+  from(artists, songs)((a,s) =>
+    where(a.id === s.artistId)
+    groupBy(a.id)  
+    compute(countDistinct(s.id)))
+]]>
 
 </script>
 
@@ -67,18 +67,19 @@ Translates into this SQL statement :
 
 <script type="syntaxhighlighter" class="brush: sql">
 
+<![CDATA[
 
-Select  
-Artist1.id as g0,  
-count(distinct Song2.id) as c0  
-From  
-Artist Artist1,  
-Song Song2  
-Where  
-(Artist1.id = Song2.artistId)  
-Group By  
-Artist1.id  
-
+Select
+  Artist1.id as g0,
+  count(distinct Song2.id) as c0
+From
+  Artist Artist1,
+  Song Song2
+Where
+  (Artist1.id = Song2.artistId)
+Group By
+  Artist1.id
+]]>
 
 </script>
 

--- a/docs/0.9.5/introduction.md
+++ b/docs/0.9.5/introduction.md
@@ -32,15 +32,15 @@ Here is a comparison of a Squeryl and a JPA version of the same query :
 
 <script type="syntaxhighlighter" class="brush: scala">
 
-//All is validated at compile time here :
+<![CDATA[
+//All is validated at compile time here:
 
-var avg: Option\[Float\] = // The compiler ‘knows’ that this query
-returns an Option\[Float\]  
-from(grades)(g =\>  
-// mathId has to by type compatible with g.subjectId to compile  
-where(g.subjectId === mathId)  
-compute(avg(g.scoreInPercentage))  
-)
+var avg: Option[Float] = // The compiler ‘knows’ that this query returns an Option[Float]
+  from(grades)(g =>
+    // mathId has to by type compatible with g.subjectId to compile
+    where(g.subjectId === mathId)
+    compute(avg(g.scoreInPercentage)))
+]]>
 
 </script>
 <!--
@@ -56,21 +56,23 @@ The equivalent JPA query invocation is subject to a runtime failure at
 five places :
 
 <script type="syntaxhighlighter" class="brush: java">
-// Equivalent JPA query  
-Query q = entityManager.createQuery(  
-//We’ll get an SQLException if there’s a typo here :  
-“SELECT AVG (g.scoreInPercentage) FROM Grades g where g.subjectId =
-:subjectId”);
 
-// a runtime exception if mathId is of the wrong type  
+<![CDATA[
+// Equivalent JPA query
+Query q = entityManager.createQuery(
+  //We’ll get an SQLException if there’s a typo here:
+  “SELECT AVG (g.scoreInPercentage) FROM Grades g where g.subjectId = :subjectId”);
+
+// a runtime exception if mathId is of the wrong type
 q.setParameter(1, mathId); // or if 1 is not the right index
 
-// ClassCastExeption possible  
+// ClassCastExeption possible
 Number avg = (Number) q.getSingleResult();
 
-// NullPointerException if the query returns null  
-//(ex.: if there are no math Grades in the table)  
-avg.floatValue();  
+// NullPointerException if the query returns null
+//(ex.: if there are no math Grades in the table)
+avg.floatValue();
+]]>
 
 </script>
 

--- a/docs/0.9.5/joins.md
+++ b/docs/0.9.5/joins.md
@@ -11,26 +11,24 @@ A two table join :
 
 <script type="syntaxhighlighter" class="brush: scala">
 
+<![CDATA[
 
-class Playlist(var id: Long, var name: String, var path: String) extends
-KeyedEntity\[Long\] {
+class Playlist(var id: Long, var name: String, var path: String) extends KeyedEntity[Long] {
 
-import MusicDb.\_
+  import MusicDb._
 
-// a two table join :  
-def songsInPlaylistOrder =  
-from(playlistElements, songs)((ple, s) =\>  
-where(ple.playlistId = id and ple.songId = s.id)  
-select(s)  
-orderBy(ple.songNumber asc)  
-)  
-}  
-
+  // a two table join:
+  def songsInPlaylistOrder =
+    from(playlistElements, songs)((ple, s) =>
+    where(ple.playlistId = id and ple.songId = s.id)
+    select(s)
+    orderBy(ple.songNumber asc))
+}
+]]>
 
 </script>
 
-The select clause can return anything that is in the scope, for example
-it  
+The select clause can return anything that is in the scope, for example it  
 could return both joined objects with a Tuple2 : select((s, ple))
 
 The **join** keyword
@@ -38,19 +36,17 @@ The **join** keyword
 
 <script type="syntaxhighlighter" class="brush: scala">
 
+<![CDATA[
 
+val ratingsForAllSongs =
+  join(songs, ratings.leftOuter)((s,r) =>
+    select(s, r)
+   on(s.id === r.map(_.songId)))
 
-val ratingsForAllSongs =  
-join(songs, ratings.leftOuter)((s,r) =\>  
-select(s, r)  
-on(s.id === r.map(\_.songId))  
-)
-
-for(sr \<- ratingsForAllSongs)  
-println(sr.\_1.title + " rating is " +  
-sr.\_2.map(r =\> r.appreciationScore.toString).getOrElse(“not rated”))
-
-
+for(sr <- ratingsForAllSongs)
+  println(sr._1.title + " rating is " +
+    sr._2.map(r => r.appreciationScore.toString).getOrElse(“not rated”))
+]]>
 
 </script>
 
@@ -58,22 +54,23 @@ produces :
 
 <script type="syntaxhighlighter" class="brush: sql">
 
+<![CDATA[
 
-Select  
-Song1.id as Song1\_id,  
-Rating2.songId as Rating2\_songId,  
-Rating2.songId as Rating2\_songId,  
-Rating2.appreciationScore as Rating2\_appreciationScore,  
-Rating2.userId as Rating2\_userId,  
-Song1.year as Song1\_year,  
-Song1.title as Song1\_title,  
-Song1.filePath as Song1\_filePath,  
-Song1.artistId as Song1\_artistId,  
-Song1.id as Song1\_id  
-From  
-Song Song1  
-left outer join Rating as Rating2 on (Song1.id = Rating2.songId)  
-
+Select
+  Song1.id as Song1_id,
+  Rating2.songId as Rating2_songId,
+  Rating2.songId as Rating2_songId,
+  Rating2.appreciationScore as Rating2_appreciationScore,
+  Rating2.userId as Rating2_userId,
+  Song1.year as Song1_year,
+  Song1.title as Song1_title,
+  Song1.filePath as Song1_filePath,
+  Song1.artistId as Song1_artistId,
+  Song1.id as Song1_id
+From
+  Song Song1
+left outer join Rating as Rating2 on (Song1.id = Rating2.songId)
+]]>
 
 </script>
 
@@ -81,36 +78,36 @@ A join can also be an agreate query, for example :
 
 <script type="syntaxhighlighter" class="brush: scala">
 
+<![CDATA[
 
-val q =  
-join(artists,songs.leftOuter)((a,s)=\>  
-groupBy(a.id, a.firstName)  
-compute(countDistinct(s.map(\_.id)))  
-on(a.id === s.map(\_.authorId))  
-)
-
-
+val q =
+  join(artists,songs.leftOuter)((a,s)=>
+    groupBy(a.id, a.firstName)
+    compute(countDistinct(s.map(_.id)))
+    on(a.id === s.map(_.authorId)))
+]]>
 
 </script>
 
 The type of this query is
 **Query\[GroupWithMeasures\[(Long,String),Long\]**, it produces the
-following SQL :
+following SQL:
 
 <script type="syntaxhighlighter" class="brush: sql">
 
+<![CDATA[
 
-Select  
-Person1.id as g0,  
-Person1.firstName as g1,  
-count(distinct Song2.id) as c0  
-From  
-Person Person1  
-left outer join Song as Song2 on (Person1.id = Song2.authorId)  
-Group By  
-Person1.id,  
-Person1.firstName  
-
+Select
+  Person1.id as g0,
+  Person1.firstName as g1,
+  count(distinct Song2.id) as c0
+From
+  Person Person1
+left outer join Song as Song2 on (Person1.id = Song2.authorId)
+Group By
+  Person1.id,
+  Person1.firstName
+]]>
 
 </script>
 
@@ -118,15 +115,15 @@ Of course, like in SQL, a **join** can have a where clause :
 
 <script type="syntaxhighlighter" class="brush: scala">
 
+<![CDATA[
 
-val q =  
-join(artists,songs.leftOuter)((a,s)=\>  
-where(a.id in myListOfArtistId)  
-groupBy(a.id, a.firstName)  
-compute(countDistinct(s.map(\_.id)))  
-on(a.id === s.map(\_.authorId))  
-)  
-
+val q =
+  join(artists,songs.leftOuter)((a,s)=>
+    where(a.id in myListOfArtistId)
+    groupBy(a.id, a.firstName)
+    compute(countDistinct(s.map(_.id)))
+    on(a.id === s.map(\_.authorId)))
+]]>
 
 </script>
 
@@ -136,12 +133,11 @@ the i’th ‘on’ condition corresponds to the i’th table expression :
 <script type="syntaxhighlighter" class="brush: scala">
 
 
+<![CDATA[
 
-join(T, A1, A2,… AN)((a1,a2,…,aN) =\>  
-…  
-on(…condition for a1…,…condition for a2…,……condition for aN…, )  
-)  
-
+join(T, A1, A2,… AN)((a1,a2,…,aN) => …
+  on(…condition for a1…,…condition for a2…,……condition for aN…, ))
+]]>
 
 </script>
 
@@ -160,17 +156,16 @@ member to be an Option\[Rating\]
 <script type="syntaxhighlighter" class="brush: scala">
 
 
+<![CDATA[
 
-val ratingsForAllSongs =  
-from(songs, ratings)((s,r) =\>  
-select((s, leftOuterJoin(r, s.id === r.songId)))  
-)
+val ratingsForAllSongs =
+  from(songs, ratings)((s,r) =>
+    select((s, leftOuterJoin(r, s.id === r.songId))))
 
-for(sr \<- ratingsForAllSongs)  
-println(sr.\_1.title + " rating is " +  
-sr.\_2.map(r =\> r.appreciationScore.toString).getOrElse(“not rated”))
-
-
+for(sr <- ratingsForAllSongs)
+  println(sr._1.title + " rating is " +
+    sr._2.map(r => r.appreciationScore.toString).getOrElse(“not rated”))
+]]>
 
 </script>
 
@@ -190,21 +185,21 @@ The SQL of the previous query is :
 
 <script type="syntaxhighlighter" class="brush: sql">
 
+<![CDATA[
 
-Select  
-Song1.id as Song1\_id,  
-Rating2.songId as Rating2\_songId,  
-Rating2.songId as Rating2\_songId,  
-Rating2.appreciationScore as Rating2\_appreciationScore,  
-Rating2.userId as Rating2\_userId,  
-Song1.year as Song1\_year,  
-Song1.title as Song1\_title,  
-Song1.filePath as Song1\_filePath,  
-Song1.artistId as Song1\_artistId,  
-Song1.id as Song1\_id  
-From  
-Song Song1  
-left outer join Rating as Rating2 on (Song1.id = Rating2.songId)  
-
+Select
+  Song1.id as Song1_id,
+  Rating2.songId as Rating2_songId,
+  Rating2.appreciationScore as Rating2_appreciationScore,
+  Rating2.userId as Rating2_userId,
+  Song1.year as Song1_year,
+  Song1.title as Song1_title,
+  Song1.filePath as Song1_filePath,
+  Song1.artistId as Song1_artistId,
+  Song1.id as Song1_id
+From
+  Song Song1
+left outer join Rating as Rating2 on (Song1.id = Rating2.songId)
+]]>
 
 </script>

--- a/docs/0.9.5/limitations.md
+++ b/docs/0.9.5/limitations.md
@@ -15,15 +15,14 @@ therefore is not useable as a subquery in a from or join clause*
 
 <script type="syntaxhighlighter" class="brush: scala">
 
-
+<![CDATA[
 
 class Person(val firstName: val age: Int)
 
-ASchema extends Schema {  
-val people = table\[Person\]  
+ASchema extends Schema {
+  val people = table[Person]
 }
-
-
+]]>
 
 </script>
 
@@ -32,27 +31,23 @@ clause :
 
 <script type="syntaxhighlighter" class="brush: scala">
 
+<![CDATA[
 
+val peopleQuery1 = from(people)(p => select(p.age))
 
-val peopleQuery1 =  
-from(people)(p =\> select(p.age))
+val peopleQuery2 = from(people)(p => select(p.age, p.name))
 
-val peopleQuery2 =  
-from(people)(p =\> select(p.age, p.name))
+// NOT OK in a from clause:
+from(peopleQuery1)(x => select(x))
+from(peopleQuery2)(x => select(x._1))
 
-// NOT OK in a from clause :  
-from(peopleQuery1)(x =\> select(x))  
-from(peopleQuery2)(x =\> select(x.\_1))
-
-// results in runtime error:  
-// Sub query returns a primitive type or a Tuple of primitive type, and
-therefore  
+// results in runtime error:
+// Sub query returns a primitive type or a Tuple of primitive type, and therefore
 // is not useable as a subquery in a from or join clause
 
-// OK in an IN clause :  
-from(aTable)(t =\> t.aField in (peopleQuery1))
-
-
+// OK in an IN clause:
+from(aTable)(t => t.aField in (peopleQuery1))
+]]>
 
 </script>
 
@@ -60,27 +55,24 @@ from(aTable)(t =\> t.aField in (peopleQuery1))
 
 <script type="syntaxhighlighter" class="brush: scala">
 
+<![CDATA[
 
+// this query is not nestable (in a from clause):
+val nonNestablePeopleQuery1 = from(people)(p => select(p.age))
 
-// this query is not nestable (in a from clause) :  
-val nonNestablePeopleQuery1 =  
-from(people)(p =\> select(p.age))
+// this one is:
+val nestablePeopleQuery1 = from(people)(p => select(p))
 
-// this one is :  
-val nestablePeopleQuery1 =  
-from(people)(p =\> select(p))
+// therefore nesting in a ‘from’ is possible:
+from(nestablePeopleQuery1)(x => select(x.age))
 
-// therefore nesting in a ‘from’ is possible :  
-from(nestablePeopleQuery1)(x =\> select(x.age))
+// unlike this one, which will fail at definition time:
+from(nonNestablePeopleQuery1)(x => select(x))
 
-// unlike this one, which will fail at definition time :  
-from(nonNestablePeopleQuery1)(x =\> select(x))
-
-// this kind of nesting is possible (provided of course that the  
-// type of aField is compatible with p.age) :  
-from(t)(x =\> where(x.aField in (nonNestablePeopleQuery1)) select(x))
-
-
+// this kind of nesting is possible (provided of course that the
+// type of aField is compatible with p.age):
+from(t)(x => where(x.aField in (nonNestablePeopleQuery1)) select(x))
+]]>
 
 </script>
 
@@ -90,13 +82,13 @@ from(t)(x =\> where(x.aField in (nonNestablePeopleQuery1)) select(x))
 <script type="syntaxhighlighter" class="brush: scala">
 
 
+<![CDATA[
 
-// Not OK :  
-val q1 = people.where(p=\> p.age + 1 \> 40)
+// Not OK:
+val q1 = people.where(p=> p.age + 1 > 40)
 
-// OK :  
-val q2 = people.where(p=\> p.age plus 1 gt 40)
-
-
+// OK:
+val q2 = people.where(p=> p.age plus 1 gt 40)
+]]>
 
 </script>

--- a/docs/0.9.5/miscellaneous.md
+++ b/docs/0.9.5/miscellaneous.md
@@ -27,18 +27,17 @@ or to a scalar, as following example illustrates :
 
 <script type="syntaxhighlighter" class="brush: scala">
 
+<![CDATA[
 
+val x1:Option[Float] = from(aTable)(t=> compute(avg(t.anInt)))
 
-val x1:Option\[Float\] = from(aTable)(t=\> compute(avg(t.anInt)))
+// or with an ascription:
 
-// or with an ascription :
+val x2 = from(aTable)(t=> compute(avg(t.anInt))) : :Option[Float]
 
-val x2 = from(aTable)(t=\> compute(avg(t.anInt))) : :Option\[Float\]
-
-val t:(Option\[Float\],Option\[String\]) = from(aTable)(t=\>
-compute(avg(t.anInt), min(t.aString)))
-
-
+val t:(Option[Float],Option[String]) = from(aTable)(t=>
+  compute(avg(t.anInt), min(t.aString)))
+]]>
 
 </script>
 
@@ -46,15 +45,14 @@ Instead of the (slightly) more verbose way :
 
 <script type="syntaxhighlighter" class="brush: scala">
 
+<![CDATA[
 
+val x:Option[Float] = from(aTable)(t =>
+  compute(avg(t.anInt))).single._1
 
-val x:Option\[Float\] = from(aTable)(t=\>
-compute(avg(t.anInt))).single.\_1
-
-val t:(Option\[Float\],Option\[String\]) = from(aTable)(t=\>
-compute(avg(t.anInt), min(t.aString))).single
-
-
+val t:(Option[Float],Option[String]) = from(aTable)(t =>
+  compute(avg(t.anInt), min(t.aString))).single
+]]>
 
 </script>
 

--- a/docs/0.9.5/occ.md
+++ b/docs/0.9.5/occ.md
@@ -18,13 +18,12 @@ fetched with).
 
 <script type="syntaxhighlighter" class="brush: scala">
 
+<![CDATA[
 
-
-class Book(val id: Long,  
-var title: String,  
-var authorId: Long) extends KeyedEntity\[Long\] with Optimistic
-
-
+class Book(val id: Long,
+  var title: String,
+  var authorId: Long) extends KeyedEntity[Long] with Optimistic
+]]>
 
 </script>
 
@@ -34,15 +33,12 @@ KeyedEntity\[\] in order extend Optimistic.
 
 <script type="syntaxhighlighter" class="brush: scala">
 
-
-
-trait Optimistic {  
-self: KeyedEntity\[\_\] =\>
-
-protected val occVersionNumber = 0  
+<![CDATA[
+trait Optimistic {
+  self: KeyedEntity[_] =>
+    protected val occVersionNumber = 0
 }
-
-
+]]>
 
 </script>
 

--- a/docs/0.9.5/pagination.md
+++ b/docs/0.9.5/pagination.md
@@ -11,23 +11,23 @@ Example :
 
 <script type="syntaxhighlighter" class="brush: scala">
 
+<![CDATA[
 
-
-def searchForBooks(title : String, offset: Int, pageLength: Int) =  
-from(books)(b =\>  
-where(b.title like title)  
-select(b)  
-orderBy(b.title asc)  
-).page(offset, pageLength)
+def searchForBooks(title: String, offset: Int, pageLength: Int) =
+  from(books)(b =>
+    where(b.title like title)
+    select(b)
+    orderBy(b.title asc)
+  ).page(offset, pageLength)
 
 val pageLength = 10
 
-val page1 = searchForBooks(“The Art of%”, pageLength \* 0, pageLength)
+val page1 = searchForBooks(“The Art of%”, pageLength * 0, pageLength)
 
-val page2 = searchForBooks(“The Art of%”, pageLength \* 1, pageLength)
+val page2 = searchForBooks(“The Art of%”, pageLength * 1, pageLength)
 
-val page3 = searchForBooks(“The Art of%”, pageLength \* 2, pageLength)  
-
+val page3 = searchForBooks(“The Art of%”, pageLength * 2, pageLength)
+]]>
 
 </script>
 

--- a/docs/0.9.5/performance-profiling.md
+++ b/docs/0.9.5/performance-profiling.md
@@ -12,36 +12,30 @@ the an execution of the test suite.
 
 <script type="syntaxhighlighter" class="brush: scala">
 
-
+<![CDATA[
 
 // This will create an H2 database file named ‘db-usage-stats.h2.db’
 
-val localH2SinkStatisticsListener =
-LocalH2SinkStatisticsListener.initializeOverwrite(“\~/db-usage-stats”)
+val localH2SinkStatisticsListener = LocalH2SinkStatisticsListener.initializeOverwrite(“\~/db-usage-stats”)
 
-// Sessions that are to be profiled must be given an instance of the  
-// LocalH2SinkStatisticsListener, note the 3rd parameter of the Session
-construcor :
+// Sessions that are to be profiled must be given an instance of the
+// LocalH2SinkStatisticsListener, note the 3rd parameter of the Session constructor:
 
-SessionFactory.concreteFactory = Some(()=\>  
-new Session(  
-java.sql.DriverManager.getConnection(….),  
-new H2Adapter,  
-Some(localH2SinkStatisticsListener)  
+SessionFactory.concreteFactory = Some(()=>
+  new Session(
+    java.sql.DriverManager.getConnection(….),
+    new H2Adapter,
+    Some(localH2SinkStatisticsListener)
 )
 
-// … run your load or usage simulation here …//
+// … run your load or usage simulation here …
 
-// Now the h2 database db-usage-stats.h2.db is filled with usage
-stats,  
-// the following method will generate a statistic summary charting the
-top 10 queries  
-// with longest run time, highest cumulated run time, etc :
+// Now the h2 database db-usage-stats.h2.db is filled with usage stats,
+// the following method will generate a statistic summary charting the top 10 queries
+// with longest run time, highest cumulated run time, etc:
 
-localH2SinkStatisticsListener.generateStatSummary(new
-java.io.File(“./profileOfH2Tests.html”), 10)
-
-
+localH2SinkStatisticsListener.generateStatSummary(new java.io.File(“./profileOfH2Tests.html”), 10)
+]]>
 
 </script>
 

--- a/docs/0.9.5/relations.md
+++ b/docs/0.9.5/relations.md
@@ -25,31 +25,26 @@ stateful relations are described [here](stateful-relations.html) .
 <script type="syntaxhighlighter" class="brush: scala">
 
 
+<![CDATA[
 
 object SchoolDb extends Schema {
 
-val courses = table\[Course\]
+  val courses = table[Course]
+  val subjects = table[Subject]
 
-val subjects = table\[Subject\]
-
-val subjectToCourses =  
-oneToManyRelation(subjects, courses).  
-via((s,c) =\> s.id === c.subjectId)  
+  val subjectToCourses =
+    oneToManyRelation(subjects, courses).
+    via((s,c) => s.id === c.subjectId)
 }
 
 class Course(val subjectId: Long) extends SchoolDb2Object {
-
-lazy val subject: ManyToOne\[Subject\] =
-SchoolDb.subjectToCourses.right(this)  
+  lazy val subject: ManyToOne[Subject] = SchoolDb.subjectToCourses.right(this)
 }
 
 class Subject(val name: String) extends SchoolDb2Object {
-
-lazy val courses: OneToMany\[Course\] =
-SchoolDb.subjectToCourses.left(this)  
+  lazy val courses: OneToMany[Course] = SchoolDb.subjectToCourses.left(this)
 }
-
-
+]]>
 
 </script>
 
@@ -61,35 +56,31 @@ that assigns the keys while leaving the database unchanged. The
 
 <script type="syntaxhighlighter" class="brush: scala">
 
+<![CDATA[
 
-trait OneToMany\[M\] extends Query\[M\] {
+trait OneToMany[M] extends Query[M] {
 
-/  
-\* @param the object on the ‘many side’ to be associated with this  
-\*  
-\* Sets the foreign key of ‘m’ to refer to the primary key of the ‘one’
-instance  
-\*/  
-def assign(m: M): M
+  /* @param the object on the ‘many side’ to be associated with this
+   * 
+   * Sets the foreign key of ‘m’ to refer to the primary key of the ‘one’ instance
+   */
+  def assign(m: M): M
 
-/  
-\* Calls ‘assign(m)’ and persists the changes the database, by inserting
-or updating ‘m’, depending  
-\* on if it has been persisted or not.  
-\*/  
-def associate(m: M): M
+  /* Calls ‘assign(m)’ and persists the changes the database, by inserting or updating ‘m’, depending
+   * on if it has been persisted or not.
+   */
+  def associate(m: M): M
 
-def deleteAll: Int  
+  def deleteAll: Int
 }
 
-trait ManyToOne\[O \<: KeyedEntity\[\_\]\] extends Query\[O\] {
+trait ManyToOne[O <: KeyedEntity[_]] extends Query[O] {
 
-def assign(one: O): O
+  def assign(one: O): O
 
-def delete: Boolean  
+  def delete: Boolean
 }
-
-
+]]>
 
 </script>
 
@@ -107,43 +98,35 @@ The association table can have other fields besides the *left* and
 
 <script type="syntaxhighlighter" class="brush: scala">
 
+<![CDATA[
 
-
-class CourseSubscription(val courseId: Int, val studentId: Int, val
-grade: Float) extends KeyedEntity\[CompositeKey2\[Int,Int\]\] {  
-def id = compositeKey(courseId, studentId)  
+class CourseSubscription(val courseId: Int, val studentId: Int, val grade: Float) extends KeyedEntity[CompositeKey2[Int,Int]] {
+  def id = compositeKey(courseId, studentId)
 }
 
 object SchoolDb extends Schema {
 
-val students = table\[Student\]
+  val students = table[Student]
+  val courses = table[Course]
 
-val courses = table\[Course\]
-
-// courseSubscriptions is a ManyToManyRelation, it extends
-Table\[CourseSubscriptions\]  
-val courseSubscriptions =  
-manyToManyRelation(courses, students).  
-via\[CourseSubscription\]((c,s,cs) =\> (cs.studentId = s.id, c.id =
-cs.courseId))  
+  // courseSubscriptions is a ManyToManyRelation, it extends Table[CourseSubscriptions]
+  val courseSubscriptions =
+    manyToManyRelation(courses, students).
+    via[CourseSubscription]((c,s,cs) => (cs.studentId = s.id, c.id = cs.courseId))
 }
 
 class Course(val subjectId: Long) extends SchoolDb2Object {
 
-//students is a ManyToMany\[Student,CourseSubscription\], it extends
-Query\[Students\]  
-lazy val students = SchoolDb2.courseSubscriptions.left(this)  
+  //students is a ManyToMany[Student,CourseSubscription], it extends Query[Students]
+  lazy val students = SchoolDb2.courseSubscriptions.left(this)
 }
 
-class Student(val firstName: String, val lastName: String) extends
-SchoolDb2Object {
+class Student(val firstName: String, val lastName: String) extends SchoolDb2Object {
 
-//courses is a ManyToMany\[Course,CourseSubscription\], it extends
-Query\[Course\]  
-lazy val courses = SchoolDb2.courseSubscriptions.right(this)  
+  //courses is a ManyToMany[Course,CourseSubscription], it extends Query[Course]
+  lazy val courses = SchoolDb2.courseSubscriptions.right(this)
 }
-
-
+]]>
 
 </script>
 
@@ -151,7 +134,7 @@ Examples of many to many relation usage :
 
 <script type="syntaxhighlighter" class="brush: scala">
 
-
+<![CDATA[
 
 // the following two lines are equivalent, they both create  
 // and insert a CourseSubscription, with the proper foreign keys :
@@ -160,27 +143,26 @@ physics.students.associate(olga)
 
 olga.courses.associate(physics)
 
-//physics.students is a Query\[Student\] selecting all stutents  
+//physics.students is a Query[Student] selecting all stutents  
 //in the physics course :
 
-println(“students of physics :”)  
-for(s \<- physics.students)  
-println(s.fullName)
+println(“students of physics :”)
+for(s <- physics.students)
+  println(s.fullName)
 
 // we can get acces the association objects of  
 // a relation member, here we have the CourseSubscription  
-// of the physics course :  
-physics.students.associations : Query\[CourseSubscription\]
+// of the physics course:
+physics.students.associations: Query[CourseSubscription]
 
 // just like for OneToMany, we have the ‘assign’ methods,  
 // that only creates the association object without inserting :  
 val cs:CourseSubscription = olga.courses.assign(physics)
 
-// cs must be manually inserted for the association to be  
-// persistent :  
+// cs must be manually inserted for the association to be
+// persistent:
 SchoolDb.courseSubscriptions.insert(cs)
-
-
+]]>
 
 </script>
 
@@ -188,92 +170,68 @@ SchoolDb.courseSubscriptions.insert(cs)
 
 <script type="syntaxhighlighter" class="brush: scala">
 
+<![CDATA[
+/* This trait is what is referred by both the left and right side of a manyToMany relation.
+ * Type parameters are:
+ * O: the type at the “other” side of the relation
+ * A: the association type i.e. the entity in the “middle” of the relation
+ *
+ * Object mapping to the “middle” entity are called “association objects”
+ *
+ * this trait extends Query\[O\] and can be queried against like a normal query.
+ *
+ * Note that this trait is used on both “left” and “right” sides of the relation,
+ * but in a given relation
+ */
+trait ManyToMany[O <: KeyedEntity*],A <: KeyedEntity[*] extends Query[O] {
 
-/  
-\* This trait is what is referred by both the left and right side of a
-manyToMany relation.  
-\* Type parameters are :  
-\* O: the type at the “other” side of the relation  
-\* A: the association type i.e. the entity in the “middle” of the
-relation  
-\*  
-\* Object mapping to the “middle” entity are called “association
-objects”  
-\*  
-\* this trait extends Query\[O\] and can be queried against like a
-normal query.  
-\*  
-\* Note that this trait is used on both “left” and “right” sides of the
-relation,  
-\* but in a given relation  
-\*/  
-trait ManyToMany\[O \<: KeyedEntity*\],A \<: KeyedEntity\[*\] extends
-Query\[O\] {
+  /* @param a: the association object
+   *
+   * Sets the foreign keys of the association object to the primary keys of the left and right side,
+   * this method does not update the database, changes to the association object must be done for
+   * the operation to be persisted. Alternatively the method ‘associate(o, a)’ will call this assign(o, a)
+   * and persist the changes.
+   */
+  def assign(o: O, a: A): A
 
-/  
-\* @param a: the association object  
-\*  
-\* Sets the foreign keys of the association object to the primary keys
-of the left and right side,  
-\* this method does not update the database, changes to the association
-object must be done for  
-\* the operation to be persisted. Alternatively the method ‘associate(o,
-a)’ will call this assign(o, a)  
-\* and persist the changes.  
-\*/  
-def assign(o: O, a: A): A
+  /* @param a: the association object
+   *
+   * Calls assign(o,a) and persists the changes the database, by inserting or updating ‘a’, depending
+   * on if it has been persisted or not.
+   */
+  def associate(o: O, a: A): A
 
-/  
-\* @param a: the association object  
-\*  
-\* Calls assign(o,a) and persists the changes the database, by inserting
-or updating ‘a’, depending  
-\* on if it has been persisted or not.  
-\*/  
-def associate(o: O, a: A): A
+  /* Creates a new association object ‘a’ and calls assign(o,a)
+   */
+  def assign(o: O): A
 
-/  
-\* Creates a new association object ‘a’ and calls assign(o,a)  
-\*/  
-def assign(o: O): A
+  /* Creates a new association object ‘a’ and calls associate(o,a)
+   *
+   * Note that this method will fail if the association object has NOT NULL constraint fields appart from the
+   * foreign keys in the relations
+   *
+   */
+  def associate(o: O): A
 
-/  
-\* Creates a new association object ‘a’ and calls associate(o,a)  
-\*  
-\* Note that this method will fail if the association object has NOT
-NULL constraint fields appart from the  
-\* foreign keys in the relations  
-\*  
-\*/  
-def associate(o: O): A
+  /* Causes the deletion of the ‘Association object’ between this side and the other side
+   * of the relation.
+   * @return true if ‘o’ was associated (if an association object existed between ‘this’ and ‘o’) false otherwise
+   */
+  def dissociate(o: O): Boolean
 
-/  
-\* Causes the deletion of the ‘Association object’ between this side and
-the other side  
-\* of the relation.  
-\* @return true if ‘o’ was associated (if an association object existed
-between ‘this’ and ‘o’) false otherwise  
-\*/
+  /* Deletes all “associations” relating this “side” to the other
+   */
+  def dissociateAll: Int
 
-def dissociate(o: O): Boolean
+  /* a Query returning all of this member’s association entries
+   */
+  def associations: Query[A]
 
-/  
-\* Deletes all “associations” relating this “side” to the other  
-\*/  
-def dissociateAll: Int
-
-/  
-\* a Query returning all of this member’s association entries  
-\*/  
-def associations: Query\[A\]
-
-/  
-\* @return a Query of Tuple2 containing all objects on the ‘other side’
-along with their association object  
-\*/  
-def associationMap: Query\[(O,A)\]  
-}  
-
+  /* @return a Query of Tuple2 containing all objects on the ‘other side’ along with their association object
+   */
+  def associationMap: Query[(O,A)]
+}
+]]>
 
 </script>
 
@@ -289,46 +247,39 @@ foreign key constraints to be inhibited.
 
 <script type="syntaxhighlighter" class="brush: scala">
 
-
+<![CDATA[
 
 object SchoolDb2 extends Schema {
 
-val professors = table\[Professor\]  
-val students = table\[Student\]  
-val courses = table\[Course\]  
-val subjects = table\[Subject\]
+  val professors = table[Professor]
+  val students = table[Student]
+  val courses = table[Course]
+  val subjects = table[Subject]
 
-val courseAssignments =  
-manyToManyRelation(professors, courses).  
-via\[CourseAssignment\]((p,c,a) =\> (p.id = a.professorId, a.courseId =
-c.id))
+  val courseAssignments =
+    manyToManyRelation(professors, courses).
+     via[CourseAssignment]((p,c,a) => (p.id = a.professorId, a.courseId = c.id))
 
-val courseSubscriptions =  
-manyToManyRelation(courses, students).  
-via\[CourseSubscription\]((c,s,cs) =\> (cs.studentId = s.id, c.id =
-cs.courseId))
+  val courseSubscriptions =
+    manyToManyRelation(courses, students).
+      via[CourseSubscription]((c,s,cs) => (cs.studentId = s.id, c.id = cs.courseId))
 
-val subjectToCourses =  
-oneToManyRelation(subjects, courses).  
-via((s,c) =\> s.id === c.subjectId)
+  val subjectToCourses =
+    oneToManyRelation(subjects, courses).
+      via((s,c) => s.id === c.subjectId)
 
-// the default constraint for all foreign keys in this schema :  
-override def applyDefaultForeignKeyPolicy(foreignKeyDeclaration:
-ForeignKeyDeclaration) =  
-foreignKeyDeclaration.constrainReference
+  // the default constraint for all foreign keys in this schema:
+  override def applyDefaultForeignKeyPolicy(foreignKeyDeclaration: ForeignKeyDeclaration) =
+    foreignKeyDeclaration.constrainReference
 
-//now we will redefine some of the foreign key constraints :  
-//if we delete a subject, we want all courses to be deleted  
-subjectToCourses.foreignKeyDeclaration.constrainReference(onDelete
-cascade)
+  //now we will redefine some of the foreign key constraints:
+  //if we delete a subject, we want all courses to be deleted
+  subjectToCourses.foreignKeyDeclaration.constrainReference(onDelete cascade)
 
-//when a course is deleted, all of the subscriptions will get deleted
-:  
-courseSubscriptions.leftForeignKeyDeclaration.constrainReference(onDelete
-cascade)  
+  //when a course is deleted, all of the subscriptions will get deleted:
+  courseSubscriptions.leftForeignKeyDeclaration.constrainReference(onDelete cascade)
 }
-
-
+]]>
 
 </script>
 

--- a/docs/0.9.5/scalap.md
+++ b/docs/0.9.5/scalap.md
@@ -16,9 +16,9 @@ compile:
 
 <script type="syntaxhighlighter" class="brush: java">
 
-
-scala.Option<int> anOptionalInt  
-
+<![CDATA[
+scala.Option<int> anOptionalInt
+]]>
 
 </script>
 
@@ -26,9 +26,9 @@ While an analogous definition in Scala would compile:
 
 <script type="syntaxhighlighter" class="brush: scala">
 
-
-val anOptionalInt:Option\[Int\]  
-
+<![CDATA[
+val anOptionalInt:Option[Int]
+]]>
 
 </script>
 

--- a/docs/0.9.5/schema-definition.md
+++ b/docs/0.9.5/schema-definition.md
@@ -13,51 +13,46 @@ that are grouped in a org.squeryl.Schema singleton.
 
 <script type="syntaxhighlighter" class="brush: scala">
 
-
-import org.squeryl.PrimitiveTypeMode.\_  
-import org.squeryl.Schema  
-import org.squeryl.annotations.Column  
-import java.util.Date  
+<![CDATA[
+import org.squeryl.PrimitiveTypeMode._
+import org.squeryl.Schema
+import org.squeryl.annotations.Column
+import java.util.Date
 import java.sql.Timestamp
 
-class Author(val id: Long,  
-val firstName: String,  
-val lastName: String,  
-val email: Option\[String\]) {  
-def this() = this(0,“”,“”,Some(“”))  
+class Author(val id: Long,
+  val firstName: String,
+  val lastName: String,
+  val email: Option[String]) {
+    def this() = this(0,“”,“”,Some(“”))
+  }
+
+  // fields can be mutable or immutable
+  class Book(val id: Long,
+      var title: String,
+      @Column(“AUTHOR_ID”) // the default ‘exact match’ policy can be overriden
+      var authorId: Long,
+      var coAuthorId: Option[Long]) {
+
+  def this() = this(0,“”,0,Some(0L))
 }
 
-// fields can be mutable or immutable
-
-class Book(val id: Long,  
-var title: String,  
-@Column(“AUTHOR\_ID”) // the default ‘exact match’ policy can be
-overriden  
-var authorId: Long,  
-var coAuthorId: Option\[Long\]) {
-
-def this() = this(0,“”,0,Some(0L))  
-}
-
-class Borrowal(val id: Long,  
-val bookId: Long,  
-val borrowerAccountId: Long,  
-val scheduledToReturnOn: Date,  
-val returnedOn: Option\[Timestamp\],  
-val numberOfPhonecallsForNonReturn: Int)
+class Borrowal(val id: Long,
+  val bookId: Long,
+  val borrowerAccountId: Long,
+  val scheduledToReturnOn: Date,
+  val returnedOn: Option[Timestamp],
+  val numberOfPhonecallsForNonReturn: Int)
 
 object Library extends Schema {
 
-//When the table name doesn’t match the class name, it is specified here
-:  
-val authors = table\[Author\](“AUTHORS”)
+  //When the table name doesn’t match the class name, it is specified here:  
+  val authors = table[Author](“AUTHORS”)
 
-val books = table\[Book\]
-
-val borrowals = table\[Borrowal\]  
+  val books = table[Book]
+  val borrowals = table[Borrowal]
 }
-
-
+]]>
 
 </script>
 
@@ -69,28 +64,23 @@ influence the DDL generation with the following declarations :
 
 <script type="syntaxhighlighter" class="brush: scala">
 
+<![CDATA[
 
+object Library extends Schema {
+  …
+  …
+  on(borrowals)(b => declare(
+    b.numberOfPhonecallsForNonReturn defaultsTo(0),
+    b.borrowerAccountId is(indexed),
+    columns(b.scheduledToReturnOn, b.borrowerAccountId) are(indexed)))
 
-object Library extends Schema {  
-…  
-…  
-on(borrowals)(b =\> declare(  
-b.numberOfPhonecallsForNonReturn defaultsTo(0),  
-b.borrowerAccountId is(indexed),  
-columns(b.scheduledToReturnOn, b.borrowerAccountId) are(indexed)  
-))
-
-on(authors)(s =\> declare(  
-s.email is(unique,indexed(“idxEmailAddresses”)), //indexes can be named
-explicitely  
-s.firstName is(indexed),  
-s.lastName is(indexed, dbType(“varchar(255)”)), // the default column
-type can be overriden  
-columns(s.firstName, s.lastName) are(indexed)  
-))  
+  on(authors)(s => declare(
+    s.email is(unique,indexed(“idxEmailAddresses”)), //indexes can be named explicitely
+    s.firstName is(indexed),
+    s.lastName is(indexed, dbType(“varchar(255)”)), // the default column type can be overriden
+    columns(s.firstName, s.lastName) are(indexed)))
 }
-
-
+]]>
 
 </script>
 
@@ -118,15 +108,13 @@ Use Schema.printDdl to print your schema :
 
 <script type="syntaxhighlighter" class="brush: scala">
 
+<![CDATA[
+def printDdl: Unit = printDdl(println(_))
 
+def printDdl(pw: PrintWriter): Unit = printDdl(pw.println(_))
 
-def printDdl: Unit = printDdl(println(\_))
-
-def printDdl(pw: PrintWriter): Unit = printDdl(pw.println(\_))
-
-def printDdl(pw: String =\> Unit): Unit = {…}
-
-
+def printDdl(pw: String => Unit): Unit = {…}
+]]>
 
 </script>
 
@@ -196,20 +184,18 @@ Enumerations are persisted by ‘int’ columns
 
 <script type="syntaxhighlighter" class="brush: scala">
 
-
-
-object Tempo extends Enumeration {  
-type Tempo = Value  
-val Largo = Value(1, “Largo”)  
-val Allegro = Value(2, “Allegro”)  
-val Presto = Value(3, “Presto”)  
+<![CDATA[
+object Tempo extends Enumeration {
+  type Tempo = Value
+  val Largo = Value(1, “Largo”)
+  val Allegro = Value(2, “Allegro”)
+  val Presto = Value(3, “Presto”)
 }
 
-class Song(name: String, tempo: Tempo) {  
-def this() = this(“”,Tempo.Largo)  
+class Song(name: String, tempo: Tempo) {
+  def this() = this(“”,Tempo.Largo)
 }
-
-
+]]>
 
 </script>
 
@@ -234,18 +220,17 @@ in the scope where database objects and queries are defined :
 
 <script type="syntaxhighlighter" class="brush: scala">
 
+<![CDATA[
+import org.squeryl.PrimitiveTypeMode._
 
+class Song(val id: Long,
+  val title: String,
+  val artistId: Long,
+  val filePath: Option[String],
+  val year: Int)
 
-import org.squeryl.PrimitiveTypeMode.\_
-
-class Song(val id: Long,  
-val title: String,  
-val artistId: Long,  
-val filePath: Option\[String\],  
-val year: Int)
-
-from(songs)(s =\> where(s.title like “funk”) select(s))  
-
+from(songs)(s => where(s.title like “funk”) select(s))
+]]>
 
 </script>
 
@@ -266,17 +251,16 @@ LogicalBoolean which is what the where clause takes :
 
 <script type="syntaxhighlighter" class="brush: scala">
 
+<![CDATA[
+from(songs)(s =>
+  where(s.year.~ > 1965)
+select(s))
 
-from(songs)(s =\>  
-where(s.year.\~ \> 1965)  
-select(s)  
-)  
-// or use ‘gt’ instead of \> :  
-from(songs)(s =\>  
-where(s.year gt 1965)  
-select(s)  
-)  
-
+// or use ‘gt’ instead of >:
+from(songs)(s =>
+  where(s.year gt 1965)
+  select(s))
+]]>
 
 </script>
 
@@ -284,17 +268,15 @@ It is also needed in the following case :
 
 <script type="syntaxhighlighter" class="brush: scala">
 
-
-from(songs)(s =\>  
-where(s.year.\~ + 10 = 1965)
-      select(s)
-    )
-    // or use 'plus'
-    from(songs)(s =\>
-      where(s.year plus 10 = 1965)  
-select(s)  
-)  
-
+<![CDATA[
+from(songs)(s => 
+  where(s.year.~ + 10 = 1965)
+  select(s))
+// or use 'plus'
+from(songs)(s =>
+  where(s.year plus 10 = 1965)
+  select(s)) 
+]]>
 
 </script>
 
@@ -317,51 +299,42 @@ into the scope where statements are defined.
 
 <script type="syntaxhighlighter" class="brush: scala">
 
+<![CDATA[
+import org.squeryl.customtypes.CustomTypesMode._
+import org.squeryl.customtypes._
 
+/* An example of trait that can be mixed into CustomType,
+ * to add meta data and validation
+ */
+trait Domain[A] {
+  self: CustomType =>
 
-import org.squeryl.customtypes.CustomTypesMode.\_  
-import org.squeryl.customtypes.\_
+  def label: String
+  def validate(a: A): Unit
+  def value: A
 
-/  
-\* An example of trait that can be mixed into CustomType,  
-\* to add meta data and validation  
-\*/  
-trait Domain\[A\] {  
-self: CustomType =\>
-
-def label: String  
-def validate(a: A): Unit  
-def value: A
-
-validate(value)  
+  validate(value)
 }
 
-class Age(v: Int) extends IntField(v) with Domain\[Int\] {  
-def validate(a: Int) = assert(a \> 0, “age must be positive, got ” +
-a)  
-def label = “age”  
+class Age(v: Int) extends IntField(v) with Domain[Int] {
+  def validate(a: Int) = assert(a > 0, “age must be positive, got ” + a)
+  def label = “age”
 }
 
-class FirstName(v: String) extends StringField(v) with Domain\[String\]
-{  
-def validate(s: String) = assert(s.length \<= 50, “first name is waaaay
-to long : ” + s)  
-def label = “first name”  
+class FirstName(v: String) extends StringField(v) with Domain[String] {
+  def validate(s: String) = assert(s.length \<= 50, “first name is waaaay to long : ” + s)
+  def label = “first name”
 }
 
-class WeightInKilograms(v: Double) extends DoubleField(v) with
-Domain\[Double\] {  
-def validate(d:Double) = assert(d \> 0, “weight must be positive, got ”
-+ d)  
-def label = “weight (in kilograms)”  
+class WeightInKilograms(v: Double) extends DoubleField(v) with Domain[Double] {
+  def validate(d:Double) = assert(d > 0, “weight must be positive, got ” + d)
+  def label = “weight (in kilograms)”
 }
 
-class Patient(val firstName: FirstName, val age: Age, val weight:
-WeightInKilograms)
+class Patient(val firstName: FirstName, val age: Age, val weight: WeightInKilograms)
 
-val heavyWeights = from(patients)(p =\> where(p.weight \> 250)
-select(p))
-
-
+val heavyWeights = from(patients)(p => where(p.weight > 250)
+  select(p))
+]]>
 
 </script>

--- a/docs/0.9.5/selects.md
+++ b/docs/0.9.5/selects.md
@@ -12,15 +12,13 @@ is itself a Queryable\[T\] and a lazy Iterable\[T\].
 
 <script type="syntaxhighlighter" class="brush: scala">
 
-
-
+<![CDATA[
 class Artist(val id: Long, val name:String) {
 
-def songs =  
-from(MusicDb.songs)(s =\> where(s.artistId === id) select(s))
-
-}  
-
+  def songs =  
+  from(MusicDb.songs)(s => where(s.artistId === id) select(s))
+}
+]]>
 
 </script>
 
@@ -33,9 +31,9 @@ type determines the generic parameter of the Query\[R\]
 
 <script type="syntaxhighlighter" class="brush: scala">
 
-
-def select\[R\](r: =\>R): R  
-
+<![CDATA[
+def select[R](r: =>R): R
+]]>
 
 </script>
 
@@ -43,23 +41,23 @@ The select expression will be evaluated for every row returned by the
 query.
 
 It is also possible to select with alternative (shorter but less
-generic) syntax :
+generic) syntax:
 
 <script type="syntaxhighlighter" class="brush: scala">
 
-
+<![CDATA[
 class Song(var title: String, var artistId: Long) extends KeyedEntity {
 
-import MusicDb.\_ // the schema can be imported in the scope
+  import MusicDb._ // the schema can be imported in the scope
 
-// A shorter syntax for single table queries :  
-def artist = artists.where(a =\> a.id === artistId).single
+  // A shorter syntax for single table queries:
+  def artist = artists.where(a => a.id === artistId).single
 
-// lookup by key is available because Artist extends  
-// KeyedEntity\[Long\] :  
-def lookupArtist = artists.lookup(artistId)  
-}  
-
+  // lookup by key is available because Artist extends
+  // KeyedEntity[Long]:
+  def lookupArtist = artists.lookup(artistId)
+}
+]]>
 
 </script>
 
@@ -81,14 +79,13 @@ into other queries :
 
 <script type="syntaxhighlighter" class="brush: scala">
 
-
-def songsInPlaylistOrder =  
-from(playlistElements, songs)((ple, s) =\>  
-where(ple.playlistId = id and ple.songId = s.id)  
-select(s)  
-orderBy(ple.songNumber asc)  
-)  
-
+<![CDATA[
+def songsInPlaylistOrder =
+  from(playlistElements, songs)((ple, s) =>
+  where(ple.playlistId = id and ple.songId = s.id)
+  select(s)
+  orderBy(ple.songNumber asc))
+]]>
 
 </script>
 
@@ -101,14 +98,12 @@ the from clause :
 
 <script type="syntaxhighlighter" class="brush: scala">
 
-
-
-val songsFromThe60sInFunkAndLatinJazzPlaylist2 =  
-from(funkAndLatinJazz.songsInPlaylistOrder)(s=\>  
-where(s.id === 123)  
-select(s)  
-)  
-
+<![CDATA[
+val songsFromThe60sInFunkAndLatinJazzPlaylist2 =
+  from(funkAndLatinJazz.songsInPlaylistOrder)(s=>
+  where(s.id === 123)
+  select(s))
+]]>
 
 </script>
 
@@ -118,19 +113,17 @@ Joins can also be nested in the where clause just like in SQL :
 
 <script type="syntaxhighlighter" class="brush: scala">
 
+<![CDATA[
+val songsFromThe60sInFunkAndLatinJazzPlaylist =
+  from(songs)(s=>
+    where(s.id in
+      from(funkAndLatinJazz.songsInPlaylistOrder)
+      (s2 => select(s2.id)))
+    select(s))
 
-val songsFromThe60sInFunkAndLatinJazzPlaylist =  
-from(songs)(s=\>  
-where(s.id in  
-from(funkAndLatinJazz.songsInPlaylistOrder)  
-(s2 =\> select(s2.id))  
-)  
-select(s)  
-)
-
-for(s \<- songsFromThe60sInFunkAndLatinJazzPlaylist)  
-println(s.title + " : " + s.year)  
-
+for(s <- songsFromThe60sInFunkAndLatinJazzPlaylist)
+  println(s.title + " : " + s.year)
+]]>
 
 </script>
 
@@ -138,38 +131,34 @@ The SQL generated for the above statement is :
 
 <script type="syntaxhighlighter" class="brush: sql">
 
-
-Select  
-Song1.year as Song1\_year,  
-Song1.title as Song1\_title,  
-Song1.filePath as Song1\_filePath,  
-Song1.artistId as Song1\_artistId,  
-Song1.id as Song1\_id  
-From  
-Song Song1  
-Where  
-(Song1.id in  
-(Select  
-q3.Song5\_id as q3\_Song5\_id  
-From  
-(Select  
-Song5.year as Song5\_year,  
-Song5.title as Song5\_title,  
-Song5.filePath as Song5\_filePath,  
-Song5.artistId as Song5\_artistId,  
-Song5.id as Song5\_id  
-From  
-PlaylistElement PlaylistElement4,  
-Song Song5  
-Where  
-((PlaylistElement4.playlistId = ?) and (PlaylistElement4.songId =
-Song5.id))  
-Order By  
-PlaylistElement4.songNumber Asc  
-) q3  
-))
-
-
+<![CDATA[
+Select
+  Song1.year as Song1_year,
+  Song1.title as Song1_title,
+  Song1.filePath as Song1_filePath,
+  Song1.artistId as Song1_artistId,
+  Song1.id as Song1_id
+From
+  Song Song1
+Where
+  (Song1.id in
+    (Select
+    q3.Song5_id as q3_Song5_id
+From
+  (Select
+    Song5.year as Song5_year,
+    Song5.title as Song5_title,
+    Song5.filePath as Song5_filePath,
+    Song5.artistId as Song5_artistId,
+    Song5.id as Song5_id
+  From
+    PlaylistElement PlaylistElement4,
+    Song Song5
+  Where
+    ((PlaylistElement4.playlistId = ?) and (PlaylistElement4.songId = Song5.id))
+    Order By
+      PlaylistElement4.songNumber Asc) q3))
+]]>
 
 </script>
 
@@ -188,14 +177,13 @@ For example:
 
 <script type="syntaxhighlighter" class="brush: scala">
 
-
-val studentsWithAnAddress =  
-from(students)(s =\>  
-where(exists(from(addresses)((a) =\> where(s.addressId === a.id)
-select(a.id))))  
-select(s)  
-)  
-
+<![CDATA[
+val studentsWithAnAddress =
+  from(students)(s =>
+    where(exists(from(addresses)((a) => where(s.addressId === a.id)
+    select(a.id))))
+    select(s))
+]]>
 
 </script>
 
@@ -203,26 +191,25 @@ The SQL generated for the above statement is :
 
 <script type="syntaxhighlighter" class="brush: sql">
 
-
-Select  
-Student8.name as Student8\_name,  
-Student8.age as Student8\_age,  
-Student8.isMultilingual as Student8\_isMultilingual,  
-Student8.lastName as Student8\_lastName,  
-Student8.id as Student8\_id,  
-Student8.addressId as Student8\_addressId,  
-Student8.gender as Student8\_gender  
+<![CDATA[
+Select
+  Student8.name as Student8_name,  
+  Student8.age as Student8_age,  
+  Student8.isMultilingual as Student8_isMultilingual,  
+  Student8.lastName as Student8_lastName,  
+  Student8.id as Student8_id,  
+  Student8.addressId as Student8_addressId,  
+  Student8.gender as Student8_gender  
 From  
-Student Student8  
+  Student Student8  
 Where  
-(exists(Select  
-Address11.id as Address11\_id  
-From  
-Address Address11  
-Where  
-(Student8.addressId = Address11.id)  
-) )  
-
+  (exists(Select
+      Address11.id as Address11_id  
+  From  
+    Address Address11  
+  Where  
+    (Student8.addressId = Address11.id)))
+]]>
 
 </script>
 
@@ -234,9 +221,9 @@ that has a ‘distinct’ select clause :
 
 <script type="syntaxhighlighter" class="brush: scala">
 
-
-from(songs)(s =\> select(&(s.title))).distinct  
-
+<![CDATA[
+from(songs)(s => select(&(s.title))).distinct  
+]].
 
 </script>
 
@@ -248,8 +235,8 @@ that has a ‘forUpdate’ locking directive :
 
 <script type="syntaxhighlighter" class="brush: scala">
 
-
-aTable.where(t =\> t.aField === aValue).forUpdate  
-
+<![CDATA[
+aTable.where(t => t.aField === aValue).forUpdate
+]]>
 
 </script>

--- a/docs/0.9.5/sessions-and-tx.md
+++ b/docs/0.9.5/sessions-and-tx.md
@@ -12,16 +12,16 @@ transactions can be invoked :
 
 <script type="syntaxhighlighter" class="brush: scala">
 
-
+<![CDATA[
 import org.squeryl.SessionFactory
 
 Class.forName(“org.postgresql.Driver”);
 
-SessionFactory.concreteFactory = Some(()=\>  
-Session.create(  
-java.sql.DriverManager.getConnection(“…”),  
-new PostgreSqlAdapter))  
-
+SessionFactory.concreteFactory = Some(()=>
+  Session.create(
+    java.sql.DriverManager.getConnection(“…”),
+    new PostgreSqlAdapter))
+]]>
 
 </script>
 
@@ -31,29 +31,27 @@ become available :
 
 <script type="syntaxhighlighter" class="brush: scala">
 
+<![CDATA[
+import org.squeryl.PrimitiveTypeMode._
 
-import org.squeryl.PrimitiveTypeMode.\_
-
-//Squeryl database interaction must occur in a transaction block :  
-transaction {  
-books.insert(new Author(1, “Michel”,“Folco”))  
-val a = from(authors)(a=\> where(a.lastName === “Folco”) select(a))  
+//Squeryl database interaction must occur in a transaction block:
+transaction {
+  books.insert(new Author(1, “Michel”,“Folco”))
+  val a = from(authors)(a=> where(a.lastName === “Folco”) select(a))
 }
 
-inTransaction {  
-authors.where(a=\> a.lastName === “Pouchkine”)
+inTransaction {
+  authors.where(a=> a.lastName === “Pouchkine”)
 
-//when in a transaction, the current session can be obtained with :  
-val s = Session.currentSession  
-}  
-
+  //when in a transaction, the current session can be obtained with:
+  val s = Session.currentSession
+}
+]]>
 
 </script>
 
-The ‘transaction’ function binds the session to the current thread for
-the duration  
-of the block, so any method called directly **and indirectly** from the
-block  
+The ‘transaction’ function binds the session to the current thread for the duration  
+of the block, so any method called directly **and indirectly** from the block  
 will be *in the context* of the transaction.
 
 ### Distinction between transaction and inTransaction
@@ -83,16 +81,12 @@ code (before any Squeryl code gets to execute).
 
 <script type="syntaxhighlighter" class="brush: scala">
 
-
-
-SessionFactorye.externalTransactionManagementAdapter = Some(  
-() =\> new Session(  
-…obtain the current session here …  
-new OracleAdapter  
-)  
-)
-
-
+<![CDATA[
+SessionFactorye.externalTransactionManagementAdapter = Some(
+  () => new Session(
+    …obtain the current session here …
+    new OracleAdapter))
+]]>
 
 </script>
 
@@ -103,13 +97,11 @@ Given an org.squeryl.Session, Squeryl statements can be issued with the
 
 <script type="syntaxhighlighter" class="brush: scala">
 
-
-
-using(squerylSession) {  
-// your Squeryl code here…  
+<![CDATA[
+using(squerylSession) {
+  // your Squeryl code here…
 }
-
-
+]]>
 
 </script>
 

--- a/docs/0.9.5/stateful-relations.md
+++ b/docs/0.9.5/stateful-relations.md
@@ -17,36 +17,26 @@ invoke instead of **left** and **right** :
 
 <script type="syntaxhighlighter" class="brush: scala">
 
-
-
+<![CDATA[
 class Course(val subjectId: Long) extends SchoolDb2Object {
 
-//students is a ManyToMany\[Student,CourseSubscription\], it extends
-Query\[Students\]  
-lazy val students = SchoolDb2.courseSubscriptions.leftStateful(this)  
+  //students is a ManyToMany[Student,CourseSubscription], it extends Query[Students]
+  lazy val students = SchoolDb2.courseSubscriptions.leftStateful(this)
 }
 
-class Student(val firstName: String, val lastName: String) extends
-SchoolDb2Object {
-
-//courses is a ManyToMany\[Course,CourseSubscription\], it extends
-Query\[Course\]  
-lazy val courses = SchoolDb2.courseSubscriptions.rightStateful(this)  
+class Student(val firstName: String, val lastName: String) extends SchoolDb2Object {
+  //courses is a ManyToMany[Course,CourseSubscription], it extends Query[Course]
+  lazy val courses = SchoolDb2.courseSubscriptions.rightStateful(this)
 }
 
 class Course(val subjectId: Long) extends SchoolDb2Object {
-
-lazy val subject: ManyToOne\[Subject\] =
-SchoolDb.subjectToCourses.rightStateful(this)  
+  lazy val subject: ManyToOne[Subject] = SchoolDb.subjectToCourses.rightStateful(this)
 }
 
 class Subject(val name: String) extends SchoolDb2Object {
-
-lazy val courses: OneToMany\[Course\] =
-SchoolDb.subjectToCourses.leftStateful(this)  
+  lazy val courses: OneToMany[Course] = SchoolDb.subjectToCourses.leftStateful(this)
 }
-
-
+]]>
 
 </script>
 
@@ -60,31 +50,22 @@ relation is in fact a wrapper over a stateless one, with caching.
 
 <script type="syntaxhighlighter" class="brush: scala">
 
+<![CDATA[
+class StatefulOneToMany[M](val relation: OneToMany[M]) extends Iterable[M] {
 
-
-class StatefulOneToMany\[M\](val relation: OneToMany\[M\]) extends
-Iterable\[M\] {
-
-def refresh: Unit
-
-def associate(m: M):Unit
-
-def deleteAll: Int  
+  def refresh: Unit
+  def associate(m: M):Unit
+  def deleteAll: Int
 }
 
-class StatefulManyToOne\[O \<: KeyedEntity\[\_\]\](val relation:
-ManyToOne\[O\]) {
+class StatefulManyToOne[O <: KeyedEntity[_]](val relation: ManyToOne[O]) {
 
-def refresh: Unit
-
-def one: Option\[O\]
-
-def assign(o: O): Unit
-
-def delete: Boolean  
+  def refresh: Unit
+  def one: Option[O]
+  def assign(o: O): Unit
+  def delete: Boolean
 }
-
-
+]]>
 
 </script>
 
@@ -95,20 +76,16 @@ apparent :
 
 <script type="syntaxhighlighter" class="brush: scala">
 
+<![CDATA[
+class StatefulManyToMany[O <: KeyedEntity*],A <: KeyedEntity[*](val relation: ManyToMany[O,A]) extends Iterable[O] {
 
-
-class StatefulManyToMany\[O \<: KeyedEntity*\],A \<:
-KeyedEntity\[*\](val relation: ManyToMany\[O,A\]) extends Iterable\[O\]
-{
-
-def refresh: Unit  
-def associate(o: O, a: A)  
-def associate(o: O): A  
-def dissociate(o: O): Boolean  
-def dissociateAll: Int  
-def associations: Iterable\[A\]  
+  def refresh: Unit
+  def associate(o: O, a: A)
+  def associate(o: O): A
+  def dissociate(o: O): Boolean
+  def dissociateAll: Int
+  def associations: Iterable[A]
 }
-
-
+]]>
 
 </script>

--- a/docs/0.9.5/type-mapping.md
+++ b/docs/0.9.5/type-mapping.md
@@ -40,24 +40,18 @@ Here are some examples :
 
 <script type="syntaxhighlighter" class="brush: scala">
 
+<![CDATA[
+val q1 = from(aTable)(t => select( &(t.aLong * t.aFloat) )): Query[Double]
 
+val q2 = from(aTable)(t => compute( avg(t.aByte / t.anInt) )): Query[Option[Float]]
 
-val q1 =  
-from(aTable)(t =\> select( &(t.aLong \* t.aFloat) )) : Query\[Double\]
+val q3 = from(aTable)(t => compute( t.aByte + count )): Query[Long]
 
-val q2 =  
-from(aTable)(t =\> compute( avg(t.aByte / t.anInt) )) :
-Query\[Option\[Float\]\]
-
-val q3 =  
-from(aTable)(t =\> compute( t.aByte + count )) : Query\[Long\]
-
-val q4 = // \|\| is the concatenation operator :  
-from(aTable)(t =\>  
-select( &(t.aString \|\| t.aLong \|\| " " \|\| a.IntOption) )) :
-Query\[Option\[String\]\]
-
-
+val q4 = // || is the concatenation operator:
+from(aTable)(t =>
+  select( &(t.aString || t.aLong || " " || a.IntOption) )):
+  Query[Option[String]]
+]]>
 
 </script>
 


### PR DESCRIPTION
This PR fixes the bug filled against the main project:

https://github.com/squeryl/squeryl/issues/276

Fixing these examples can particularly help with this comment: "On a first look at some snippets one might incorrectly assume this library uses tons of unintuitive custom symbolic operators.".

Dropping pygments is related to:

https://docs.github.com/github/working-with-github-pages/troubleshooting-jekyll-build-errors-for-github-pages-sites#fixing-highlighting-errors

This is how the new pages render: https://drdub.github.io/squeryl.github.io/docs/0.9.5/introduction.html